### PR TITLE
fix: update OpenTelemetry package versions and improve health check e…

### DIFF
--- a/src/Recall.Core.Api/Program.cs
+++ b/src/Recall.Core.Api/Program.cs
@@ -58,11 +58,11 @@ app.UseCors();
 app.MapGet("/health", () => Results.Ok(new { status = "ok" }))
     .WithName("GetHealth")
     .WithTags("System")
-    .WithOpenApi(operation =>
+    .AddOpenApiOperationTransformer((operation, context, ct) =>
     {
         operation.Summary = "Health check endpoint";
         operation.Description = "Returns the health status of the API.";
-        return operation;
+        return Task.CompletedTask;
     });
 
 app.Run();

--- a/src/Recall.Core.ServiceDefaults/Recall.Core.ServiceDefaults.csproj
+++ b/src/Recall.Core.ServiceDefaults/Recall.Core.ServiceDefaults.csproj
@@ -10,10 +10,10 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request includes updates to OpenTelemetry package versions and a change to the health check endpoint's OpenAPI operation transformer. The most important changes are grouped below:

Dependency updates:

* Upgraded all `OpenTelemetry` package references in `Recall.Core.ServiceDefaults.csproj` from version `1.10.0` to `1.12.0`, ensuring the service uses the latest features and bug fixes from OpenTelemetry.

API documentation changes:

* Updated the health check endpoint in `Program.cs` to use `.AddOpenApiOperationTransformer` instead of `.WithOpenApi`, and changed the transformer to return a completed task instead of the operation object, aligning with updated API conventions.