### PR TITLE
feat: Update Azure deployment workflow and documentation for OIDC aut…

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -32,6 +32,11 @@ jobs:
     defaults:
       run:
         working-directory: infra
+    env:
+      ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      ARM_USE_OIDC: true
 
     steps:
       - name: Checkout

--- a/specs/007-azure-infra/quickstart.md
+++ b/specs/007-azure-infra/quickstart.md
@@ -188,6 +188,8 @@ terraform output
    - Action: `apply`
 4. Wait for completion (~15-20 minutes)
 
+**Note**: The workflow uses OIDC authentication automatically. The Terraform providers detect the authentication method from environment variables (`ARM_USE_OIDC`, `ARM_CLIENT_ID`, etc.) set by the workflow
+
 ---
 
 ## Step 5: Build and Push Container Images
@@ -288,6 +290,25 @@ open $WEB_URL  # macOS
 ---
 
 ## Troubleshooting
+
+### Terraform Authentication Error in GitHub Actions
+
+```
+Error: Error building ARM Config: Authenticating using the Azure CLI is only supported as a User (not a Service Principal).
+```
+
+**Cause**: Terraform is trying to use Azure CLI authentication, but GitHub Actions uses a Service Principal via OIDC.
+
+**Fix**: The workflow should set these environment variables (already configured in `.github/workflows/infra-deploy.yml`):
+```yaml
+env:
+  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  ARM_USE_OIDC: true
+```
+
+This tells Terraform to use OIDC authentication instead of Azure CLI.
 
 ### Terraform Init Fails
 


### PR DESCRIPTION
This pull request improves the Azure infrastructure deployment workflow by explicitly configuring OIDC authentication for Terraform in GitHub Actions and updating the documentation to clarify this setup and assist with troubleshooting. The changes ensure that the workflow uses the recommended authentication method and provide clear guidance for users encountering related errors.

**Workflow configuration:**

* [`.github/workflows/infra-deploy.yml`](diffhunk://#diff-103ff04ceba67f9c02591e0a80e25889bc143184a42dfadeb829a0c1496697bdR35-R39): Added environment variables (`ARM_CLIENT_ID`, `ARM_SUBSCRIPTION_ID`, `ARM_TENANT_ID`, `ARM_USE_OIDC`) to the workflow to enable OIDC authentication for Terraform when running in GitHub Actions.

**Documentation updates:**

* [`specs/007-azure-infra/quickstart.md`](diffhunk://#diff-f7a6ead8ec1d6318a0b19840f87e75fe2483ab956bbf25135ccc6d083ffeb15dR191-R192): Added a note explaining that OIDC authentication is used automatically and that Terraform providers detect this from the environment variables set by the workflow.
* [`specs/007-azure-infra/quickstart.md`](diffhunk://#diff-f7a6ead8ec1d6318a0b19840f87e75fe2483ab956bbf25135ccc6d083ffeb15dR294-R312): Added a troubleshooting section describing a common Terraform authentication error in GitHub Actions, its cause, and how the workflow's environment variables resolve it.