### PR TITLE
fix: use correct storage module output name for storage_account_id

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -55,7 +55,7 @@ module "container_apps" {
   app_insights_connection_string         = module.monitoring.app_insights_connection_string
   key_vault_id                           = module.keyvault.id
   storage_account_name                   = module.storage.storage_account_name
-  storage_account_id                     = module.storage.id
+  storage_account_id                     = module.storage.storage_account_id
   storage_connection_string              = module.storage.primary_connection_string
   storage_blob_endpoint                  = module.storage.primary_blob_endpoint
   storage_queue_name                     = module.storage.queue_name


### PR DESCRIPTION
This pull request makes a minor update to the infrastructure configuration by correcting the output variable used for the storage account ID in the `container_apps` module.

- Updated the `storage_account_id` variable in the `container_apps` module to use `module.storage.storage_account_id` instead of `module.storage.id`, ensuring the correct value is passed for the storage account ID.