### PR TITLE
fix: add missing connection_string_secret_id output to storage module

### DIFF
--- a/infra/modules/storage/outputs.tf
+++ b/infra/modules/storage/outputs.tf
@@ -30,11 +30,16 @@ output "primary_queue_endpoint" {
 
 output "primary_connection_string" {
   description = "Primary connection string"
-  value       = "DefaultEndpointsProtocol=https;AccountName=${azurerm_storage_account.main.name};AccountKey=${azurerm_storage_account.main.primary_access_key};EndpointSuffix=core.windows.net"
+  value       = azurerm_storage_account.main.primary_connection_string
   sensitive   = true
 }
 
 output "id" {
   description = "Storage account ID"
   value       = azurerm_storage_account.main.id
+}
+
+output "connection_string_secret_id" {
+  description = "Key Vault secret ID for the storage connection string"
+  value       = azurerm_key_vault_secret.storage_connection_string.id
 }


### PR DESCRIPTION
This pull request updates the outputs for the storage module to improve how the storage account connection string is managed and exposed. The main changes focus on simplifying the retrieval of the connection string and adding a new output for its storage in Key Vault.

**Outputs improvements:**

* Changed the `primary_connection_string` output to use the built-in `primary_connection_string` attribute from `azurerm_storage_account.main` instead of constructing the string manually, reducing the risk of errors and simplifying the code.
* Added a new output `connection_string_secret_id` that exposes the Key Vault secret ID where the storage connection string is stored, making it easier for consumers to reference the secret securely.