### PR TITLE
fix: resolve terraform circular dependency for resource group and sto…

### DIFF
--- a/infra/modules/container-apps/main.tf
+++ b/infra/modules/container-apps/main.tf
@@ -1,8 +1,3 @@
-data "azurerm_storage_account" "main" {
-  name                = var.storage_account_name
-  resource_group_name = var.resource_group_name
-}
-
 resource "azurerm_container_app_environment" "main" {
   name                = "recall-${var.environment}-cae"
   location            = var.location

--- a/infra/modules/documentdb/main.tf
+++ b/infra/modules/documentdb/main.tf
@@ -1,11 +1,9 @@
+data "azurerm_client_config" "current" {}
+
 resource "random_password" "admin" {
   length           = 32
   special          = true
   override_special = "!@#$%&_+-="
-}
-
-data "azurerm_resource_group" "main" {
-  name = var.resource_group_name
 }
 
 terraform {
@@ -21,7 +19,7 @@ resource "azapi_resource" "mongo_cluster" {
   type      = "Microsoft.DocumentDB/mongoClusters@2024-07-01"
   name      = "recall-${var.environment}-docdb"
   location  = var.location
-  parent_id = data.azurerm_resource_group.main.id
+  parent_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}"
   tags      = var.tags
 
   body = jsonencode({


### PR DESCRIPTION
…rage account

- Remove data source for resource group in documentdb module (now created in same plan)
- Use data.azurerm_client_config to dynamically construct parent_id path
- Remove data source for storage account in container-apps module
- Use variables passed from root module instead of reading non-existent resources

This resolves the 'Resource Group not found' and 'Storage Account not found' errors that occurred during terraform plan due to circular dependencies.