### PR TITLE
fix: remove invalid firewallRules from MongoDB Cluster resource

### DIFF
--- a/infra/modules/documentdb/main.tf
+++ b/infra/modules/documentdb/main.tf
@@ -39,13 +39,6 @@ resource "azapi_resource" "mongo_cluster" {
         targetMode = var.environment == "prod" ? "ZoneRedundantPreferred" : "Disabled"
       }
       publicNetworkAccess = "Enabled"
-      firewallRules = [
-        {
-          name           = "allow-azure-services"
-          startIpAddress = "0.0.0.0"
-          endIpAddress   = "0.0.0.0"
-        }
-      ]
     }
   }
 }


### PR DESCRIPTION
- Remove unsupported firewallRules property from azapi_resource body
- firewallRules is not valid in Microsoft.DocumentDB/mongoClusters@2024-07-01 API schema
- Public network access is already configured for Azure Services access