### PR TITLE
fix: Add required sharding property to MongoDB cluster resource

### DIFF
--- a/infra/modules/documentdb/main.tf
+++ b/infra/modules/documentdb/main.tf
@@ -38,6 +38,9 @@ resource "azapi_resource" "mongo_cluster" {
       highAvailability = {
         targetMode = var.environment == "prod" ? "ZoneRedundantPreferred" : "Disabled"
       }
+      sharding = {
+        enabled = var.environment == "prod" ? true : false
+      }
       publicNetworkAccess = "Enabled"
     }
   }


### PR DESCRIPTION
- Add sharding property to API schema for 2024-07-01
- Enable sharding for prod environments, disable for dev
- Resolves 'bad_request' error from Azure API schema validation