### PR TITLE
fix: replace invalid sharding.enabled with shardCount in documentdb t…

### DIFF
--- a/infra/modules/documentdb/main.tf
+++ b/infra/modules/documentdb/main.tf
@@ -39,7 +39,7 @@ resource "azapi_resource" "mongo_cluster" {
         targetMode = var.environment == "prod" ? "ZoneRedundantPreferred" : "Disabled"
       }
       sharding = {
-        enabled = var.environment == "prod" ? true : false
+        shardCount = var.environment == "prod" ? 3 : 1
       }
       publicNetworkAccess = "Enabled"
     }


### PR DESCRIPTION
This pull request makes a configuration adjustment to the MongoDB cluster setup in the Terraform module. The change modifies how sharding is configured based on the environment, ensuring production clusters have more shards for scalability.

- **MongoDB Cluster Configuration:**
  * Updated the `sharding` block in `azapi_resource.mongo_cluster` to set `shardCount` to 3 in production environments and 1 otherwise, instead of simply enabling or disabling sharding.