### PR TITLE
Refactor secret name for DocumentDB connection in container app and j…

### DIFF
--- a/infra/modules/container/container-app-api.bicep
+++ b/infra/modules/container/container-app-api.bicep
@@ -77,7 +77,7 @@ module apiApp 'br/public:avm/res/app/container-app:0.20.0' = {
     ]
     secrets: [
       {
-        name: 'documentdb-connection-string'
+        name: documentDbSecretName
         keyVaultUrl: '${keyVaultUri}/secrets/${documentDbSecretName}'
         identity: 'system'
       }

--- a/infra/modules/container/container-app-job.bicep
+++ b/infra/modules/container/container-app-job.bicep
@@ -107,7 +107,7 @@ module job 'br/public:avm/res/app/job:0.7.1' = {
     ]
     secrets: [
       {
-        name: 'documentdb-connection-string'
+        name: documentDbSecretName
         keyVaultUrl: '${keyVaultUri}/secrets/${documentDbSecretName}'
         identity: 'system'
       }


### PR DESCRIPTION
This pull request updates the way the DocumentDB secret is referenced in both the API and job container app modules. Instead of hardcoding the secret name, it now uses the `documentDbSecretName` variable for improved flexibility and maintainability.

Secret management improvements:

* Updated the `secrets` configuration in `container-app-api.bicep` to use the `documentDbSecretName` variable instead of the hardcoded string `'documentdb-connection-string'`.
* Updated the `secrets` configuration in `container-app-job.bicep` to use the `documentDbSecretName` variable instead of the hardcoded string `'documentdb-connection-string'`.