### PR TITLE
Normalize documentDbSecretName to lowercase in container app and job …

### DIFF
--- a/infra/modules/container/container-app-api.bicep
+++ b/infra/modules/container/container-app-api.bicep
@@ -77,7 +77,7 @@ module apiApp 'br/public:avm/res/app/container-app:0.20.0' = {
     ]
     secrets: [
       {
-        name: documentDbSecretName
+        name: toLower(documentDbSecretName)
         keyVaultUrl: '${keyVaultUri}/secrets/${documentDbSecretName}'
         identity: 'system'
       }

--- a/infra/modules/container/container-app-job.bicep
+++ b/infra/modules/container/container-app-job.bicep
@@ -107,7 +107,7 @@ module job 'br/public:avm/res/app/job:0.7.1' = {
     ]
     secrets: [
       {
-        name: documentDbSecretName
+        name: toLower(documentDbSecretName)
         keyVaultUrl: '${keyVaultUri}/secrets/${documentDbSecretName}'
         identity: 'system'
       }


### PR DESCRIPTION
This pull request makes a small but important change to how secret names are handled in the container app infrastructure modules. The secret names are now consistently converted to lowercase before being used, which can help prevent issues related to case sensitivity in secret management.

- Secret names passed to the `secrets` array in both `container-app-api.bicep` and `container-app-job.bicep` are now converted to lowercase using `toLower(documentDbSecretName)`. [[1]](diffhunk://#diff-deae0f8aa084e6c4ff2bc585a0d4c4923fdc6a240112efd43df59a2c991f667bL80-R80) [[2]](diffhunk://#diff-1a5c71bf6ed16b76eedf27ce782bec0a193586ad9d895a2e36c37a5ef76aa00cL110-R110)