### PR TITLE
fix: use wget instead of curl in deployment script, fix secret name m…

### DIFF
--- a/infra/modules/container/container-app-api.bicep
+++ b/infra/modules/container/container-app-api.bicep
@@ -121,7 +121,7 @@ module apiApp 'br/public:avm/res/app/container-app:0.20.0' = {
           }
           {
             name: 'ConnectionStrings__recalldb'
-            secretRef: 'documentdb-connection-string'
+            secretRef: toLower(documentDbSecretName)
           }
         ]
         probes: [

--- a/infra/modules/container/container-app-job.bicep
+++ b/infra/modules/container/container-app-job.bicep
@@ -139,7 +139,7 @@ module job 'br/public:avm/res/app/job:0.7.1' = {
           }
           {
             name: 'ConnectionStrings__recalldb'
-            secretRef: 'documentdb-connection-string'
+            secretRef: toLower(documentDbSecretName)
           }
           {
             name: 'Storage__BlobServiceUri'

--- a/infra/modules/database/documentdb.bicep
+++ b/infra/modules/database/documentdb.bicep
@@ -110,9 +110,9 @@ resource createDatabaseScript 'Microsoft.Resources/deploymentScripts@2020-10-01'
       MONGOSH_DIR="/tmp/mongosh-${MONGOSH_VERSION}-linux-x64"
       MONGOSH_BIN="${MONGOSH_DIR}/bin/mongosh"
 
-      # Download mongosh
+      # Download mongosh using wget (curl not available in AzureCLI container)
       echo "Downloading mongosh ${MONGOSH_VERSION}..."
-      curl -fsSL "${MONGOSH_URL}" -o "${MONGOSH_TGZ}"
+      wget -q "${MONGOSH_URL}" -O "${MONGOSH_TGZ}"
       
       # Verify checksum
       echo "${MONGOSH_SHA256}  ${MONGOSH_TGZ}" | sha256sum -c -


### PR DESCRIPTION
This pull request introduces improvements to secret reference handling for environment variables and enhances compatibility in the database deployment script. The main changes are grouped into two themes: secret management and deployment script reliability.

**Secret management improvements:**

* Updated the `secretRef` assignment for the `ConnectionStrings__recalldb` environment variable in both `container-app-api.bicep` and `container-app-job.bicep` to use the lowercase value of `documentDbSecretName`, improving consistency and reducing potential errors from casing mismatches. [[1]](diffhunk://#diff-deae0f8aa084e6c4ff2bc585a0d4c4923fdc6a240112efd43df59a2c991f667bL124-R124) [[2]](diffhunk://#diff-1a5c71bf6ed16b76eedf27ce782bec0a193586ad9d895a2e36c37a5ef76aa00cL142-R142)

**Deployment script reliability:**

* Changed the database deployment script in `documentdb.bicep` to use `wget` instead of `curl` for downloading `mongosh`, ensuring compatibility with the AzureCLI container environment where `curl` may not be available.