### PR TITLE
fix: use Key Vault URI from output instead of reconstructing it

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -191,6 +191,7 @@ module apiApp 'modules/container/container-app-api.bicep' = {
     containerAppsEnvironmentId: containerAppsEnvironment.outputs.environmentId
     containerRegistryName: containerRegistry.outputs.acrName
     keyVaultName: keyVault.outputs.keyVaultName
+    keyVaultUri: keyVault.outputs.keyVaultUri
     appConfigurationName: appConfiguration.outputs.appConfigName
     appInsightsConnectionString: appInsights.outputs.connectionString
     storageAccountName: storageAccount.outputs.storageAccountName
@@ -199,6 +200,7 @@ module apiApp 'modules/container/container-app-api.bicep' = {
   }
   dependsOn: [
     resourceGroupModule
+    documentDb // Ensure DocumentDB secret is created in KeyVault before container app tries to reference it
   ]
 }
 
@@ -211,12 +213,14 @@ module enrichmentJob 'modules/container/container-app-job.bicep' = {
     containerAppsEnvironmentId: containerAppsEnvironment.outputs.environmentId
     containerRegistryName: containerRegistry.outputs.acrName
     keyVaultName: keyVault.outputs.keyVaultName
+    keyVaultUri: keyVault.outputs.keyVaultUri
     appConfigurationName: appConfiguration.outputs.appConfigName
     appInsightsConnectionString: appInsights.outputs.connectionString
     storageAccountName: storageAccount.outputs.storageAccountName
   }
   dependsOn: [
     resourceGroupModule
+    documentDb // Ensure DocumentDB secret is created in KeyVault before container job tries to reference it
   ]
 }
 

--- a/infra/modules/container/container-app-api.bicep
+++ b/infra/modules/container/container-app-api.bicep
@@ -19,6 +19,9 @@ param containerImageTag string = 'latest'
 @description('Key Vault name for secret references')
 param keyVaultName string
 
+@description('Key Vault URI')
+param keyVaultUri string
+
 @description('App Configuration name')
 param appConfigurationName string
 
@@ -44,7 +47,6 @@ var appName = 'aca-recall-api-${environmentName}'
 var registryServer = '${containerRegistryName}.azurecr.io'
 var imageName = '${registryServer}/recall-api:${containerImageTag}'
 var activeRevisionsMode = environmentName == 'prod' ? 'Multiple' : 'Single'
-var keyVaultUri = 'https://${keyVaultName}.${environment().suffixes.keyvaultDns}'
 var documentDbSecretName = 'DocumentDbConnectionString'
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {

--- a/infra/modules/container/container-app-job.bicep
+++ b/infra/modules/container/container-app-job.bicep
@@ -19,6 +19,9 @@ param containerImageTag string = 'latest'
 @description('Key Vault name')
 param keyVaultName string
 
+@description('Key Vault URI')
+param keyVaultUri string
+
 @description('App Configuration name')
 param appConfigurationName string
 
@@ -52,7 +55,6 @@ param memory string = '2Gi'
 var jobName = 'acj-recall-enrichment-${environmentName}'
 var registryServer = '${containerRegistryName}.azurecr.io'
 var imageName = '${registryServer}/recall-enrichment:${containerImageTag}'
-var keyVaultUri = 'https://${keyVaultName}.${environment().suffixes.keyvaultDns}'
 var documentDbSecretName = 'DocumentDbConnectionString'
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {


### PR DESCRIPTION
- Add keyVaultUri parameter to container-app-api and container-app-job modules
- Pass keyVaultUri from keyVault.outputs.keyVaultUri in main.bicep
- Add documentDb dependency to ensure secret exists before container apps deploy
- Fixes ContainerAppSecretKeyVaultUrlInvalid deployment error