### PR TITLE
feat(infra): implement deployment token retrieval for Static Web App

### DIFF
--- a/infra/modules/web/static-web-app-token.bicep
+++ b/infra/modules/web/static-web-app-token.bicep
@@ -1,0 +1,9 @@
+@description('Name of the existing Static Web App')
+param staticSiteName string
+
+resource staticSiteResource 'Microsoft.Web/staticSites@2024-04-01' existing = {
+  name: staticSiteName
+}
+
+@secure()
+output deploymentToken string = staticSiteResource.listSecrets().properties.apiKey

--- a/infra/modules/web/static-web-app.bicep
+++ b/infra/modules/web/static-web-app.bicep
@@ -51,14 +51,19 @@ module staticSite 'br/public:avm/res/web/static-site:0.9.3' = {
   }
 }
 
-resource staticSiteResource 'Microsoft.Web/staticSites@2024-04-01' existing = {
-  name: staticSiteName
+// Get deployment token after SWA is created
+module swaToken 'static-web-app-token.bicep' = {
+  name: '${staticSiteName}-token'
+  params: {
+    staticSiteName: staticSiteName
+  }
+  dependsOn: [
+    staticSite
+  ]
 }
-
-var deploymentToken = staticSiteResource.listSecrets().properties.apiKey
 
 output swaId string = staticSite.outputs.resourceId
 output swaName string = staticSite.outputs.name
 output swaDefaultHostname string = staticSite.outputs.defaultHostname
 @secure()
-output swaDeploymentToken string = deploymentToken
+output swaDeploymentToken string = swaToken.outputs.deploymentToken


### PR DESCRIPTION
This pull request refactors how the Static Web App deployment token is retrieved and exposed in the Bicep infrastructure modules. Instead of directly accessing secrets from an existing resource, it introduces a dedicated module for fetching the deployment token, improving modularity and separation of concerns.

**Deployment token retrieval and output refactor:**

* Added a new module `static-web-app-token.bicep` to encapsulate the logic for fetching the Static Web App deployment token, using the `listSecrets()` method on the existing resource.
* Updated `static-web-app.bicep` to use the new `swaToken` module for deployment token retrieval, replacing direct resource access and variable assignment with a module output.
* Changed the output `swaDeploymentToken` to source its value from the new module, ensuring the token is securely and modularly exposed.