### PR TITLE
fix(infra): update Azure login credentials to use secrets for security

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@v2
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install Container Apps extension
         run: az extension add --name containerapp --upgrade

--- a/.github/workflows/enrichment-deploy.yml
+++ b/.github/workflows/enrichment-deploy.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@v2
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install Container Apps extension
         run: az extension add --name containerapp --upgrade

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@v2
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Login to ACR
         run: az acr login --name crrecall${{ inputs.environment }}


### PR DESCRIPTION
This pull request updates the way Azure credentials are referenced in several GitHub Actions workflow files. Instead of using the `vars` context, the workflows now use the `secrets` context to access Azure credentials, which is the recommended and more secure method for handling sensitive information.

Security improvements to GitHub Actions workflows:

* Updated the Azure login steps in `.github/workflows/api-deploy.yml`, `.github/workflows/enrichment-deploy.yml`, and `.github/workflows/reusable-docker-build.yml` to use `secrets.AZURE_CLIENT_ID`, `secrets.AZURE_TENANT_ID`, and `secrets.AZURE_SUBSCRIPTION_ID` instead of `vars`, ensuring credentials are securely referenced. [[1]](diffhunk://#diff-08b5131d500e3a3481fc370228265c62721997ba11caa2a8b87afbc34ff06613L39-R41) [[2]](diffhunk://#diff-2e328b9c6aafafb5c6a708060fb86fde874110ed4d97676f95f996b3b2723bdfL39-R41) [[3]](diffhunk://#diff-c64794cb1eab8b6b47f903d99cbe8e29a1da7284cd3658a4bfbe65b7a1a94c53L35-R37)