### PR TITLE
fix(infra): inherit secrets for Docker build in deployment workflows

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -24,6 +24,7 @@ jobs:
       dockerfile: src/Recall.Core.Api/Dockerfile
       context: src
       image-name: recall-api
+    secrets: inherit
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/enrichment-deploy.yml
+++ b/.github/workflows/enrichment-deploy.yml
@@ -24,6 +24,7 @@ jobs:
       dockerfile: src/Recall.Core.Enrichment/Dockerfile
       context: src
       image-name: recall-enrichment
+    secrets: inherit
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small but important update to the deployment workflows for both the API and enrichment services. The change ensures that secrets are inherited by the build jobs in the GitHub Actions workflows, which is necessary for accessing sensitive information during the build process.

- GitHub Actions workflow improvements:
  * Updated the `build` jobs in `.github/workflows/api-deploy.yml` and `.github/workflows/enrichment-deploy.yml` to inherit secrets, allowing the build process to access required sensitive information. [[1]](diffhunk://#diff-08b5131d500e3a3481fc370228265c62721997ba11caa2a8b87afbc34ff06613R27) [[2]](diffhunk://#diff-2e328b9c6aafafb5c6a708060fb86fde874110ed4d97676f95f996b3b2723bdfR27)