### PR TITLE
fix(infra): remove placeholder image parameter and simplify image nam…

### DIFF
--- a/infra/modules/container/container-app-job.bicep
+++ b/infra/modules/container/container-app-job.bicep
@@ -16,9 +16,6 @@ param containerRegistryName string
 @description('Container image tag')
 param containerImageTag string = 'latest'
 
-@description('Use placeholder image for initial deployment (before pushing real images to ACR)')
-param usePlaceholderImage bool = true
-
 @description('Key Vault name')
 param keyVaultName string
 
@@ -57,9 +54,7 @@ param memory string = '2Gi'
 
 var jobName = 'acj-recall-enrichment-${environmentName}'
 var registryServer = '${containerRegistryName}.azurecr.io'
-var acrImageName = '${registryServer}/recall-enrichment:${containerImageTag}'
-var placeholderImage = 'mcr.microsoft.com/k8se/quickstart:latest'
-var imageName = usePlaceholderImage ? placeholderImage : acrImageName
+var imageName = '${registryServer}/recall-enrichment:${containerImageTag}'
 var documentDbSecretName = 'DocumentDbConnectionString'
 // Construct Key Vault secret URL without trailing slash duplication
 var keyVaultSecretUrl = '${keyVaultUri}secrets/${documentDbSecretName}'
@@ -108,7 +103,7 @@ module job 'br/public:avm/res/app/job:0.7.1' = {
     managedIdentities: {
       systemAssigned: true
     }
-    registries: usePlaceholderImage ? [] : [
+    registries: [
       {
         server: registryServer
         identity: 'system'
@@ -129,7 +124,7 @@ module job 'br/public:avm/res/app/job:0.7.1' = {
           cpu: cpu
           memory: memory
         }
-        env: usePlaceholderImage ? [] : [
+        env: [
           {
             name: 'ASPNETCORE_ENVIRONMENT'
             value: environmentName == 'prod' ? 'Production' : 'Development'

--- a/src/Recall.Core.Enrichment/Dockerfile
+++ b/src/Recall.Core.Enrichment/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    libasound2 \
+    libasound2t64 \
     libatk-bridge2.0-0 \
     libatk1.0-0 \
     libcups2 \


### PR DESCRIPTION
This pull request removes support for using a placeholder image during initial deployments in both the API and job container Bicep modules. The templates now always reference the actual container image from Azure Container Registry, and related conditional logic and parameters have been removed. Additionally, the Dockerfile is updated to use a newer package name for one of its dependencies.

**Bicep module simplification (removal of placeholder image logic):**

* Removed the `usePlaceholderImage` parameter and all related conditional logic from `container-app-api.bicep` and `container-app-job.bicep`, so deployments always use the specified container image from the Azure Container Registry. [[1]](diffhunk://#diff-deae0f8aa084e6c4ff2bc585a0d4c4923fdc6a240112efd43df59a2c991f667bL19-L21) [[2]](diffhunk://#diff-1a5c71bf6ed16b76eedf27ce782bec0a193586ad9d895a2e36c37a5ef76aa00cL19-L21)
* Updated image selection logic to reference only the real ACR image, eliminating the placeholder image variable and logic. [[1]](diffhunk://#diff-deae0f8aa084e6c4ff2bc585a0d4c4923fdc6a240112efd43df59a2c991f667bL51-R48) [[2]](diffhunk://#diff-1a5c71bf6ed16b76eedf27ce782bec0a193586ad9d895a2e36c37a5ef76aa00cL60-R57)
* Simplified resource definitions by removing conditional expressions for `registries`, `env`, and `probes`—these are now always populated. [[1]](diffhunk://#diff-deae0f8aa084e6c4ff2bc585a0d4c4923fdc6a240112efd43df59a2c991f667bL81-R76) [[2]](diffhunk://#diff-deae0f8aa084e6c4ff2bc585a0d4c4923fdc6a240112efd43df59a2c991f667bL102-R97) [[3]](diffhunk://#diff-deae0f8aa084e6c4ff2bc585a0d4c4923fdc6a240112efd43df59a2c991f667bL136-R131) [[4]](diffhunk://#diff-1a5c71bf6ed16b76eedf27ce782bec0a193586ad9d895a2e36c37a5ef76aa00cL111-R106) [[5]](diffhunk://#diff-1a5c71bf6ed16b76eedf27ce782bec0a193586ad9d895a2e36c37a5ef76aa00cL132-R127)
* Hardcoded the `ingressTargetPort` to `8080` in the API module, removing conditional logic.

**Dockerfile dependency update:**

* Replaced the `libasound2` package with `libasound2t64` in the `Recall.Core.Enrichment` Dockerfile to ensure compatibility with newer base images.