### PR TITLE
fix: add required action parameter to SWA deploy

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -44,6 +44,7 @@ jobs:
         uses: azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: "upload"
           app_location: "src/web"
           output_location: "dist"
           skip_app_build: true


### PR DESCRIPTION
This pull request introduces a minor configuration update to the deployment workflow. The change explicitly sets the deployment action to "upload" in the `.github/workflows/web-deploy.yml` file. This ensures that the workflow performs an upload operation during deployment.