### PR TITLE
perf: optimize SWA deployment size with chunk splitting and .swaignore

### DIFF
--- a/infra/modules/web/static-web-app.bicep
+++ b/infra/modules/web/static-web-app.bicep
@@ -26,7 +26,7 @@ param apiContainerAppResourceId string = ''
 param enableLinkedBackend bool = false
 
 var staticSiteName = 'swa-recall-${environmentName}'
-var sku = environmentName == 'prod' ? 'Standard' : 'Free'
+var sku = 'Standard'
 var linkedBackendConfig = enableLinkedBackend && apiContainerAppResourceId != '' ? {
   resourceId: apiContainerAppResourceId
   location: location

--- a/src/web/.swaignore
+++ b/src/web/.swaignore
@@ -1,0 +1,12 @@
+node_modules/
+src/
+tests/
+*.ts
+*.tsx
+*.config.ts
+*.config.js
+tsconfig*.json
+package.json
+pnpm-lock.yaml
+.env*
+*.md

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -12,4 +12,23 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+          'radix-ui': [
+            '@radix-ui/react-dialog',
+            '@radix-ui/react-dropdown-menu',
+            '@radix-ui/react-popover',
+            '@radix-ui/react-select',
+            '@radix-ui/react-tabs',
+            '@radix-ui/react-tooltip',
+          ],
+          'msal': ['@azure/msal-browser', '@azure/msal-react'],
+          'charts': ['recharts'],
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
This pull request introduces improvements to the build process and deployment configuration for the web application. The main changes include optimizing the bundling of dependencies in the Vite build, updating the static web app SKU configuration, and refining the files excluded from deployment.

Build optimization:

* Added manual chunking in `vite.config.ts` to split major dependencies (React, Radix UI, MSAL, and Recharts) into separate bundles, improving caching and load performance.

Deployment configuration:

* Changed the static web app SKU in `static-web-app.bicep` to always use `Standard`, regardless of environment, ensuring consistent resource allocation across all deployments.

Deployment exclusion:

* Updated `.swaignore` to exclude development and source files (such as `node_modules`, `src`, test files, configs, and markdown) from deployment, reducing the deployed footprint and potential security risks.