### PR TITLE
fix: deploy from dist folder directly to avoid size limit

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           action: "upload"
-          app_location: "src/web"
-          output_location: "dist"
+          app_location: "src/web/dist"
+          output_location: ""
           skip_app_build: true
           skip_api_build: true


### PR DESCRIPTION
This pull request updates the deployment configuration for the web application to better align with the current build output structure. The main change is to the Azure Static Web Apps deployment workflow, specifically how the application files are located and uploaded.

Deployment workflow updates:

* Changed the `app_location` in `.github/workflows/web-deploy.yml` from `src/web` to `src/web/dist` to point directly to the built output directory, ensuring the correct files are deployed.
* Set the `output_location` to an empty string to reflect that the build output is already in the specified `app_location`, simplifying the deployment process.