### PR TITLE
Add web deploy env vars

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -20,6 +20,10 @@ jobs:
     environment: ${{ inputs.environment }}
     env:
       VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+      VITE_AUTHORITY: ${{ vars.VITE_AUTHORITY }}
+      VITE_CLIENT_ID: ${{ vars.VITE_CLIENT_ID }}
+      VITE_API_SCOPE: ${{ vars.VITE_API_SCOPE }}
+      VITE_REDIRECT_URI: ${{ vars.VITE_REDIRECT_URI }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow configuration, adding new environment variables required for authentication and API access.

* Added `VITE_AUTHORITY`, `VITE_CLIENT_ID`, `VITE_API_SCOPE`, and `VITE_REDIRECT_URI` to the environment variables in the `.github/workflows/web-deploy.yml` file to support authentication and API integration.