### PR TITLE
fix: simplify CORS policy to allow any origin

### DIFF
--- a/src/Recall.Core.Api/Program.cs
+++ b/src/Recall.Core.Api/Program.cs
@@ -99,27 +99,11 @@ if (builder.Environment.IsDevelopment())
 }
 builder.Services.AddCors(options =>
 {
-    var additionalOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
-        ?? Array.Empty<string>();
-    var allowedOriginSet = new HashSet<string>(additionalOrigins, StringComparer.OrdinalIgnoreCase);
-
     options.AddDefaultPolicy(policy =>
     {
-        policy.SetIsOriginAllowed(origin =>
-        {
-            // Allow loopback addresses (development)
-            if (Uri.TryCreate(origin, UriKind.Absolute, out var uri) 
-                && uri.IsLoopback 
-                && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
-            {
-                return true;
-            }
-            
-            // Allow explicitly configured origins (e.g., extension origins)
-            return allowedOriginSet.Contains(origin);
-        })
-        .AllowAnyHeader()
-        .AllowAnyMethod();
+        policy.AllowAnyOrigin()
+            .AllowAnyHeader()
+            .AllowAnyMethod();
     });
 });
 


### PR DESCRIPTION
This pull request simplifies the CORS configuration in `src/Recall.Core.Api/Program.cs` by allowing requests from any origin, instead of restricting them to a configured set of allowed origins or loopback addresses. This change makes CORS less restrictive and may be intended for development or testing environments.

CORS policy changes:

* Replaced the logic that restricted allowed origins to a configured list and loopback addresses with a policy that allows any origin, any header, and any method. (`src/Recall.Core.Api/Program.cs`)