### PR TITLE
fix: correct job names in enrichment deployment workflow

### DIFF
--- a/.github/workflows/enrichment-deploy.yml
+++ b/.github/workflows/enrichment-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Enrichment Job
+name: Deploy Enrichment Service
 
 on:
   workflow_dispatch:
@@ -44,9 +44,9 @@ jobs:
       - name: Install Container Apps extension
         run: az extension add --name containerapp --upgrade
 
-      - name: Update Container Apps Job
+      - name: Update Container App
         run: |
-          az containerapp job update \
-            --name acj-recall-enrichment-${{ inputs.environment }} \
+          az containerapp update \
+            --name aca-recall-enrichment-${{ inputs.environment }} \
             --resource-group rg-recall-${{ inputs.environment }} \
             --image crrecall${{ inputs.environment }}.azurecr.io/recall-enrichment:${{ github.sha }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying the enrichment service. The main focus is to switch deployment from a Container Apps Job to a standard Container App, reflecting a change in the deployment strategy and naming conventions.

Deployment workflow updates:

* Changed the workflow name from "Deploy Enrichment Job" to "Deploy Enrichment Service" to better reflect the new deployment target.
* Updated the deployment step to use `az containerapp update` instead of `az containerapp job update`, and changed resource and container names from `acj-recall-enrichment-*` to `aca-recall-enrichment-*`, aligning with the switch from Container Apps Job to Container App.